### PR TITLE
Update hostsblock.conf

### DIFF
--- a/conf/hostsblock.conf
+++ b/conf/hostsblock.conf
@@ -111,11 +111,12 @@ blocklists=(
 'http://hosts-file.net/download/hosts.zip'		# hpHosts main anti-ad and anti-malware (hosts-file.net/)
 'http://www.malwaredomainlist.com/hostslist/hosts.txt'  # anti-malware (www.malwaredomainlist.com/)
 'http://hosts-file.net/ad_servers.txt'			# anti-ads-only version of hpHosts main list (hosts-file.net)
+'http://someonewhocares.org/hosts/hosts'		# anti-ad and anti-malware (someonewhocares.org/hosts/)
+'http://adaway.org/hosts.txt'               # blocking mobile ad and anti-analytics (adaway.org)
 ## RECOMMENDED LISTS
 'http://hosts-file.net/hphosts-partial.asp'		# hpHosts inter-release (hosts-file.net/)
 'http://hostsfile.org/Downloads/BadHosts.unx.zip'	# anti-malware (hostsfile.org/hosts.html)
 'http://hostsfile.mine.nu/Hosts.zip'			# anti-ad (hostsfile.mine.nu)
-'http://someonewhocares.org/hosts/hosts'		# anti-ad and anti-malware (someonewhocares.org/hosts/)
 'http://sysctl.org/cameleon/hosts'			# anti-ad (sysctl.org/cameleon/)
 ## OPTIONAL LISTS
 #'http://hosts-file.net/download/yahoo_servers.zip'     # hpHosts for yahoo adservers (hosts-file.net/)


### PR DESCRIPTION
It's been some time since hostsblock scripts have been using hostsblock.conf and not rc.conf (which probably should have been deleted already).
So the recent adaway source list should be added to this file as well as moving someonewhocares.org to the highly recommended group together with it.