### PR TITLE
Fix dependency check in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [ "$(whoami)" != "root" ]; then
 fi
 
 for dep in getent grep useradd groupadd gpasswd cut ps chmod chown; do
-    if $(which $dep) &>/dev/null; then
+    if which $dep &>/dev/null; then
         true
     else
         echo "$dep utility missing. Please install before running this script. Exiting..."


### PR DESCRIPTION
Removing the surrounding $() prevents the output being executed which will return an error without an argument.

install.sh fails on bash 4.419/debian sid with "getent utility missing" because it is executing "/usr/bin/getent" not just "which getent"